### PR TITLE
feat: improve skill scores for dotfiles

### DIFF
--- a/skills/a11y-audit/SKILL.md
+++ b/skills/a11y-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: a11y-audit
-description: Run an accessibility audit on a web page using a browser. Use when the user wants to check, test, or audit accessibility (a11y) on a URL or the current page.
+description: "Run a WCAG accessibility audit on a web page — checks heading hierarchy, landmark regions, color contrast, ARIA attributes, keyboard navigation, and screen reader compatibility. Use when the user wants to check, test, or audit accessibility (a11y) on a URL or the current page."
 ---
 
 Use the browser (via the Chrome/Playwright MCP) to audit the page for accessibility issues. Follow the steps below in order.

--- a/skills/grill-me/SKILL.md
+++ b/skills/grill-me/SKILL.md
@@ -1,10 +1,18 @@
 ---
 name: grill-me
-description: Stress-test a plan or design by interviewing the user relentlessly. Trigger when the user mentions "grill me" or wants to pressure-test their thinking.
+description: "Stress-test a plan, design, or architecture by interviewing the user with probing questions that surface weaknesses, edge cases, and unstated assumptions. Use when the user says 'grill me,' 'challenge my idea,' 'poke holes,' 'play devil's advocate,' 'critique my plan,' or wants to pressure-test their thinking."
 ---
 
-Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+Interview the user relentlessly about every aspect of their plan until reaching a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide a recommended answer.
 
-Ask the questions one at a time.
+Ask questions one at a time. Focus on:
 
-If a question can be answered by exploring the codebase, explore the codebase instead.
+- Unstated assumptions and implicit dependencies
+- Edge cases and failure modes
+- Scalability and maintenance implications
+- Security or correctness gaps
+- Alternative approaches that were not considered
+
+If a question can be answered by exploring the codebase, explore the codebase instead of asking.
+
+Continue until all branches of the design tree have been explored and the user confirms alignment on each decision.

--- a/skills/ray-skill/SKILL.md
+++ b/skills/ray-skill/SKILL.md
@@ -1,11 +1,17 @@
 ---
 name: ray-skill
-description: Use when user says "send to Ray," "show in Ray," "debug in Ray," "log to Ray," "display in Ray," or wants to visualize data, debug output, or show diagrams in the Ray desktop application.
+description: "Send variables, debug output, HTML, tables, and diagrams to Spatie's Ray desktop application via its HTTP API. Use when the user says 'send to Ray,' 'show in Ray,' 'debug in Ray,' 'log to Ray,' 'display in Ray,' or wants to visualize data or inspect values in Ray."
 ---
 
 # Ray Skill
 
 Ray is Spatie's desktop debugging application. Send data via HTTP POST to its local server — this is what `ray()` does under the hood.
+
+## Workflow
+
+1. **Check availability**: `GET http://localhost:23517/_availability_check` — Ray responds with 404 when running. If connection refused, Ray is not open.
+2. **Send payload**: POST a JSON request with one or more payloads (see Request Format below).
+3. **Apply modifiers** (optional): Reuse the same `uuid` to add color, label, or size to an existing entry.
 
 ## Connection
 
@@ -13,8 +19,6 @@ Ray is Spatie's desktop debugging application. Send data via HTTP POST to its lo
 | ------- | ----------- | ---------- |
 | Host    | `localhost` | `RAY_HOST` |
 | Port    | `23517`     | `RAY_PORT` |
-
-Availability check: `GET http://localhost:23517/_availability_check` — Ray responds with 404 when running.
 
 ## Request Format
 
@@ -39,7 +43,7 @@ Headers: `Content-Type: application/json`, `User-Agent: Ray 1.0`
 }
 ```
 
-Reuse the same `uuid` to apply modifiers (color, label, size) to an existing entry. Every payload requires the same `origin` object.
+Every payload requires the same `origin` object.
 
 ## Payload Types
 


### PR DESCRIPTION
Hey @GrimLink 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

<img width="1312" height="834" alt="score_card" src="https://github.com/user-attachments/assets/0d850459-8bef-40c1-909b-1b5f71ac0669" />


<details>
<summary>What changed</summary>

**ray-skill** (+26%)
- Rewrote description to include concrete capability statements (send variables, debug output, HTML, tables, diagrams) alongside the existing trigger phrases
- Added an explicit 3-step workflow section (check availability → send payload → apply modifiers) that was missing
- Moved the availability check detail into the new workflow for better sequencing

**grill-me** (+10%)
- Expanded description with additional natural trigger phrases ("challenge my idea," "poke holes," "play devil's advocate," "critique my plan")
- Added specific focus areas for probing questions (unstated assumptions, edge cases, failure modes, scalability, security)
- Added explicit completion criteria so the skill knows when the interview is done

**a11y-audit** (+4%)
- Enhanced description to list specific audit capabilities (WCAG, heading hierarchy, landmark regions, color contrast, ARIA, keyboard navigation, screen reader compatibility)

</details>

Honest disclosure. I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@yogesh-tessl](https://github.com/yogesh-tessl) - if you hit any snags.

Thanks in advance 🙏