### PR TITLE
ADD Create PHP settings template for Valet & Magento 2

### DIFF
--- a/valet/php-conf-templates/php-settings.ini
+++ b/valet/php-conf-templates/php-settings.ini
@@ -1,0 +1,17 @@
+; Increased memory limit for complex operations (e.g., Magento 2)
+memory_limit = 2G
+
+; Extended execution time for long-running processes like reindexing or imports
+max_execution_time = 18000
+
+; Increased upload size for larger files such as product images
+upload_max_filesize = 64M
+
+; Larger realpath cache to reduce filesystem lookups in large projects
+realpath_cache_size = 10M
+
+; Optimized bytecode caching memory for better performance
+opcache.memory_consumption = 512
+
+; Increased file limit for opcache to accommodate projects with many files (e.g., Magento 2)
+opcache.max_accelerated_files = 60000


### PR DESCRIPTION
This PR adds a new PHP configuration template, `valet/php-conf-templates/php-settings.ini`, specifically optimized for Magento 2 development environments.

#### Key Configurations:
- **`memory_limit = 2G`**: Provides sufficient headroom for memory-intensive Magento operations.
- **`max_execution_time = 18000`**: Accommodates long-running processes like reindexing and large data imports.
- **`upload_max_filesize = 64M`**: Allows for larger product image and asset uploads.
- **`realpath_cache_size = 10M`**: Reduces filesystem lookups, improving performance in large-scale projects.
- **`opcache.memory_consumption = 512`**: Allocates more memory for bytecode caching to speed up execution.
- **`opcache.max_accelerated_files = 60000`**: Increased to accommodate Magento's extensive codebase (60k+ files).

#### Rationale:
Standard PHP defaults are often insufficient for the complexity of Magento 2. This template provides a standardized set of performance-oriented defaults that can be easily synchronized across all local PHP versions using the project's Valet setup scripts.